### PR TITLE
Fix: show default icon when there is no matching icon

### DIFF
--- a/autoload/fern/renderer/web_devicons.vim
+++ b/autoload/fern/renderer/web_devicons.vim
@@ -67,7 +67,7 @@ function! s:get_node_symbol(node) abort
   if a:node.status is# s:STATUS_NONE
     let filename = fnamemodify(a:node.bufname, ':t')
     let extension = fnamemodify(a:node.bufname, ':e')
-    let symbol = luaeval(printf('require"nvim-web-devicons".get_icon("%s", "%s")', filename, extension))
+    let symbol = luaeval(printf('require"nvim-web-devicons".get_icon("%s", "%s", {default = true})', filename, extension))
 
   elseif a:node.status is# s:STATUS_COLLAPSED
     let symbol = ""


### PR DESCRIPTION
Thank you so much for the useful plugin!

I have tried to fix the ```v:null``` issue when there is no matching icon by adding a slight option.

Before:
![image](https://user-images.githubusercontent.com/3370483/217214933-7894ad6c-aa18-4fa2-8ea4-c611d24845b7.png)

After:
![image](https://user-images.githubusercontent.com/3370483/217215469-0ada6bd9-b871-47b6-9e90-6b2da14da723.png)
