### PR TITLE
Add feature to use nvim-web-devicons color palette.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ Or using lua:
 ```lua
 vim.g["glyph_palette#palette"] = require'fr-web-icons'.palette()
 ```
+
+### How to use nvim-web-devicons's color palette?
+
+Set `g:fern#renderer#web_devicons#use_web_devicons_color_palette` like
+
+```vim
+let g:fern#renderer#web_devicons#use_web_devicons_color_palette = v:true
+```
+
+⚠️You have to disable `glyph_palette#apply()` autocmd if you use this feature.

--- a/autoload/fern/renderer/web_devicons.vim
+++ b/autoload/fern/renderer/web_devicons.vim
@@ -60,12 +60,13 @@ function! s:render(nodes) abort
     endfor
   endif
   
-  if &filetype ==# "fern"
-    cal clearmatches()
+  if get(g:, "fern#renderer#web_devicons#use_web_devicons_color_palette", v:false)
+    if &filetype ==# "fern"
+      cal clearmatches()
+    endif
   endif
   let Profile = fern#profile#start('fern#renderer#web_devicons#s:render')
   return s:AsyncLambda.map(copy(a:nodes), { v, idx -> s:render_node(v, base, options, idx) })
-        \.catch({ e -> execute("echom " . string(e)) })
         \.finally({ -> Profile() })
 endfunction
 
@@ -131,9 +132,17 @@ function! s:render_node(node, base, options, idx) abort
   let symbol_hlgroup = s:get_node_symbol(a:node)
   let symbol = symbol_hlgroup[0]
   let hlgroup = symbol_hlgroup[1]
-  if hlgroup !=# ""
-    if &filetype ==# "fern"
-      cal matchaddpos(hlgroup, [[a:idx + 1, strlen(a:options.root_leading . leading) + 1]])
+  if get(g:, "fern#renderer#web_devicons#use_web_devicons_color_palette", v:false)
+    if hlgroup !=# ""
+      if &filetype ==# "fern"
+        cal matchaddpos(hlgroup, [[a:idx + 1, strlen(a:options.root_leading . leading) + 1]])
+        if !get(b:,'fern_web_devicons_renderer_autocmd_defined', v:false)
+          augroup fern_web_devicons_renderer
+            autocmd BufWinLeave <buffer> cal clearmatches()
+          augroup END
+          let b:fern_web_devicons_renderer_autocmd_defined = v:true
+        endif
+      endif
     endif
   endif
   let suffix = a:node.status ? '/' : ''


### PR DESCRIPTION
Feature to use nvim-web-devicons has its' color palette.

I added this feature because `g:glyph_palette#palette` can't handle when multiple colors are defined for the same icon.
(e.g. `.bashrc` and `.gitconfig` .etc)